### PR TITLE
java 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,29 +14,27 @@ ENV TOMCAT_VERSION 8.0.38
 ENV ACTIVITI_VERSION 5.21.0
 ENV MYSQL_CONNECTOR_JAVA_VERSION 5.1.40
 
-RUN wget http://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/catalina.tar.gz
-RUN wget https://github.com/Activiti/Activiti/releases/download/activiti-${ACTIVITI_VERSION}/activiti-${ACTIVITI_VERSION}.zip -O /tmp/activiti.zip
-
-# Unpack
-RUN tar xzf /tmp/catalina.tar.gz -C /opt
-RUN ln -s /opt/apache-tomcat-${TOMCAT_VERSION} /opt/tomcat
-RUN rm /tmp/catalina.tar.gz
-
-RUN unzip /tmp/activiti.zip -d /opt/activiti
-
-# Remove unneeded apps
-RUN rm -rf /opt/tomcat/webapps/examples
-RUN rm -rf /opt/tomcat/webapps/docs
+# Tomcat
+RUN wget http://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/catalina.tar.gz && \
+	tar xzf /tmp/catalina.tar.gz -C /opt && \
+	ln -s /opt/apache-tomcat-${TOMCAT_VERSION} /opt/tomcat && \
+	rm /tmp/catalina.tar.gz && \
+	rm -rf /opt/tomcat/webapps/examples && \
+	rm -rf /opt/tomcat/webapps/docs
 
 # To install jar files first we need to deploy war files manually
-RUN unzip /opt/activiti/activiti-${ACTIVITI_VERSION}/wars/activiti-explorer.war -d /opt/tomcat/webapps/activiti-explorer
-RUN unzip /opt/activiti/activiti-${ACTIVITI_VERSION}/wars/activiti-rest.war -d /opt/tomcat/webapps/activiti-rest
+RUN wget https://github.com/Activiti/Activiti/releases/download/activiti-${ACTIVITI_VERSION}/activiti-${ACTIVITI_VERSION}.zip -O /tmp/activiti.zip && \
+ 	unzip /tmp/activiti.zip -d /opt/activiti && \
+	unzip /opt/activiti/activiti-${ACTIVITI_VERSION}/wars/activiti-explorer.war -d /opt/tomcat/webapps/activiti-explorer && \
+	unzip /opt/activiti/activiti-${ACTIVITI_VERSION}/wars/activiti-rest.war -d /opt/tomcat/webapps/activiti-rest && \
+	rm -f /tmp/activiti.zip
 
 # Add mysql connector to application
-RUN wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}.zip -O /tmp/mysql-connector-java.zip
-RUN unzip /tmp/mysql-connector-java.zip -d /tmp
-RUN cp /tmp/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}-bin.jar /opt/tomcat/webapps/activiti-rest/WEB-INF/lib/
-RUN cp /tmp/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}-bin.jar /opt/tomcat/webapps/activiti-explorer/WEB-INF/lib/
+RUN wget http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}.zip -O /tmp/mysql-connector-java.zip && \
+	unzip /tmp/mysql-connector-java.zip -d /tmp && \
+	cp /tmp/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}-bin.jar /opt/tomcat/webapps/activiti-rest/WEB-INF/lib/ && \
+	cp /tmp/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}-bin.jar /opt/tomcat/webapps/activiti-explorer/WEB-INF/lib/ && \
+	rm -rf /tmp/mysql-connector-java.zip /tmp/mysql-connector-java-${MYSQL_CONNECTOR_JAVA_VERSION}
 
 # Add roles
 ADD assets /assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@
 ### http://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/
 # dockerfile/java renamed to java
 ### 
-FROM java
+FROM openjdk:7
 MAINTAINER Frank Wang "eternnoir@gmail.com"
 
 EXPOSE 8080
 
-ENV TOMCAT_VERSION 8.0.14
+ENV TOMCAT_VERSION 8.0.38
 ENV ACTIVITI_VERSION 5.21.0
-ENV MYSQL_CONNECTOR_JAVA_VERSION 5.1.33
+ENV MYSQL_CONNECTOR_JAVA_VERSION 5.1.40
 
 RUN wget http://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz -O /tmp/catalina.tar.gz
 RUN wget https://github.com/Activiti/Activiti/releases/download/activiti-${ACTIVITI_VERSION}/activiti-${ACTIVITI_VERSION}.zip -O /tmp/activiti.zip


### PR DESCRIPTION
switch to the openjdk image as the java image is deprecated
specify openjdk:7 as default java and openjdk is 8 and doesn't have importPackage 
update tomcat
update mysql connector

refactor to group related commands into their own single layer so rm reduces image size.
saving 125MB
